### PR TITLE
VER Space and SPK_CONFLICTS markup

### DIFF
--- a/spk/hassio/Makefile
+++ b/spk/hassio/Makefile
@@ -1,7 +1,8 @@
 SPK_NAME = hassio
 SPK_VERS = 20191224
-SPK_REV = 1 
+SPK_REV = 1
 SPK_ICON = src/$(SPK_NAME).png
+SPK_CONFLICTS = "homeassistant"
 SPK_DEPENDS = "Docker>=18.09.0-0506"
 DSM_UI_DIR = app
 


### PR DESCRIPTION
_Motivation:_  Possible address to comments raised in https://github.com/SynoCommunity/spksrc/pull/3732 (untested, intended as conversation detail)

### Checklist
- [n/a] Build rule `all-supported` completed successfully
- [n/a] Package upgrade completed successfully
- [partial] New installation of package completed successfully

"partial" above: the `SPK_VER` change was necessary to build only one SPK from the rev https://github.com/SynoCommunity/spksrc/pull/3732/commits/d67e38ba313651fc63a93f06ba5e5494ec335060
